### PR TITLE
Fix: add RESEND_API_KEY to build env for github actions

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -75,6 +75,8 @@ jobs:
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
+        env:
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Added RESEND_API_KEY to nextjs.yml for github workflows as well as added the secret on github.